### PR TITLE
Polymer2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+bower_components-1.x/
 bower_components/
 node_modules/
 reports
+bower-1.x.json

--- a/bower.json
+++ b/bower.json
@@ -14,14 +14,20 @@
   ],
   "dependencies": {
     "polymer": "Polymer/polymer#^1.9.1 || ^2.0.0",
-    "d2l-colors": "^2.2.3"
+    "d2l-colors": "^2.3.0"
   },
   "variants": {
     "1.x": {
       "dependencies": {
-        "polymer": "Polymer/polymer#^1.7.0",
-        "d2l-colors": "^2.2.3"
+        "polymer": "Polymer/polymer#^1.9.1",
+        "d2l-colors": "^2.3.0"
+      },
+      "resolutions": {
+        "webcomponentsjs": "^0.7"
       }
     }
+  },
+  "resolutions": {
+    "webcomponentsjs": "^v1.0.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,15 @@
     "package.json"
   ],
   "dependencies": {
-    "d2l-colors": "^2.2.3",
-    "polymer": "^1.7.0"
+    "polymer": "Polymer/polymer#^1.9.1 || ^2.0.0",
+    "d2l-colors": "mdgbayly/colors#polymer2"
+  },
+  "variants": {
+    "1.x": {
+      "dependencies": {
+        "polymer": "Polymer/polymer#^1.7.0",
+        "d2l-colors": "mdgbayly/colors#polymer2"
+      }
+    }
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -14,13 +14,13 @@
   ],
   "dependencies": {
     "polymer": "Polymer/polymer#^1.9.1 || ^2.0.0",
-    "d2l-colors": "^2.3.0"
+    "d2l-colors": "^3.0.0"
   },
   "variants": {
     "1.x": {
       "dependencies": {
         "polymer": "Polymer/polymer#^1.9.1",
-        "d2l-colors": "^2.3.0"
+        "d2l-colors": "^3.0.0"
       },
       "resolutions": {
         "webcomponentsjs": "^0.7"

--- a/bower.json
+++ b/bower.json
@@ -14,13 +14,13 @@
   ],
   "dependencies": {
     "polymer": "Polymer/polymer#^1.9.1 || ^2.0.0",
-    "d2l-colors": "mdgbayly/colors#polymer2"
+    "d2l-colors": "^2.2.3"
   },
   "variants": {
     "1.x": {
       "dependencies": {
         "polymer": "Polymer/polymer#^1.7.0",
-        "d2l-colors": "mdgbayly/colors#polymer2"
+        "d2l-colors": "^2.2.3"
       }
     }
   }

--- a/demo/index.html
+++ b/demo/index.html
@@ -4,7 +4,7 @@
 		<meta charset="utf-8">
 		<title>Typography Snapshot</title>
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
-		<script src="../../webcomponentsjs/webcomponents-lite.min.js"></script>
+		<script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 		<link rel="import" href="../d2l-typography.html">
 		<custom-style include="d2l-typography">
 			<style is="custom-style" include="d2l-typography">

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build:sass": "node-sass --output-style expanded ./test/acceptance/typography.css.scss ./test/acceptance/typography.css",
-    "postinstall": "bower install",
+    "postinstall": "polymer install --variants",
     "test": "npm run test:lint && npm run test:galen:local",
     "test:lint": "polymer lint --input d2l-typography.html d2l-typography-shared-styles.html",
     "galen:local:run": "d2l-galen test test/acceptance/typography.test.js -g factory:local",
@@ -30,7 +30,7 @@
     "d2l-galen-utils": "git+https://github.com/Brightspace/d2l-galen-utils.git#v0.2.4",
     "galenframework": "^2.3.2",
     "node-sass": "^4.5.0",
-    "polymer-cli": "^0.17.0",
+    "polymer-cli": "^1.1.0",
     "sauceconnect-runner": "git+https://github.com/Brightspace/sauceconnect-runner.git#v0.3.0"
   }
 }

--- a/polymer.json
+++ b/polymer.json
@@ -1,0 +1,6 @@
+{
+    "lint": {
+      "rules": ["polymer-2-hybrid"],
+      "ignoreWarnings": []
+    }
+}

--- a/test/acceptance/typography.test.js
+++ b/test/acceptance/typography.test.js
@@ -41,8 +41,8 @@ var browsers = {
 	})
 };
 
-var endpoint = 'http://localhost:8080/components/d2l-typography/test/acceptance/typography.html';
-var endpointMixins = 'http://localhost:8080/components/d2l-typography/test/acceptance/typography-mixins.html';
+var endpoint = 'http://localhost:8000/components/d2l-typography/test/acceptance/typography.html';
+var endpointMixins = 'http://localhost:8000/components/d2l-typography/test/acceptance/typography-mixins.html';
 var spec = 'test/acceptance/typography.gspec';
 
 polymerTests(browsers, function(test) {


### PR DESCRIPTION
Add support for Polymer 2.
The changes were minimal for typography.
I just added the Polymer 2 bower dependency , the 1.x variants and fixed up the webcomponents.js ref as polymer2 doesn't include a min.js.

Not sure about the bump to 1.9.1.
That is in all the Polymer examples but maybe we could leave it at a lower version?

Also regarding versioning of this change, I suppose this could be a minor version change as consumers are not really affected other than the Polymer 1.x version bump?