### PR TITLE
Append font-faces to head in separate style tag

### DIFF
--- a/d2l-typography.js
+++ b/d2l-typography.js
@@ -60,23 +60,29 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-typography">
 				line-height: 1.4rem;
 				@apply --d2l-font-custom;
 			}
+
 			.d2l-typography .d2l-body-standard {
 				@apply --d2l-body-standard-text;
 			}
+
 			.d2l-typography .d2l-body-compact {
 				@apply --d2l-body-compact-text;
 			}
+
 			.d2l-typography .d2l-body-small {
 				@apply --d2l-body-small-text;
 			}
+
 			.d2l-typography .d2l-label-text {
 				@apply --d2l-label-text;
 			}
+
 			.d2l-typography p,
 			.vui-typography p {
 				margin: 1rem 0;
 				@apply --d2l-font-paragraph-custom;
 			}
+
 			.d2l-typography.d2l-dyslexic,
 			.d2l-typography .d2l-dyslexic,
 			.vui-typography.vui-dyslexic,
@@ -85,50 +91,59 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-typography">
 				font-weight: 400;
 				@apply --d2l-font-dyslexic-custom;
 			}
+
 			.d2l-typography:lang(ar),
 			.d2l-typography :lang(ar),
 			.vui-typography:lang(ar),
 			.vui-typography :lang(ar) {
 				font-family: 'Arabic Transparent', 'Arabic Typesetting', 'Geeza Pro', sans-serif;
 			}
+
 			.d2l-typography:lang(zh),
 			.d2l-typography :lang(zh),
 			.vui-typography:lang(zh),
 			.vui-typography :lang(zh) {
 				font-family: 'Microsoft YaHei', 'Hiragino Sans GB', sans-serif;
 			}
+
 			.d2l-typography:lang(ko),
 			.d2l-typography :lang(ko),
 			.vui-typography:lang(ko),
 			.vui-typography :lang(ko) {
 				font-family: 'Apple SD Gothic Neo', Dotum, sans-serif;
 			}
+
 			.d2l-typography:lang(ja),
 			.d2l-typography :lang(ja),
 			.vui-typography:lang(ja),
 			.vui-typography :lang(ja) {
 				font-family: 'Hiragino Kaku Gothic Pro', 'Meiyro', sans-serif;
 			}
+
 			.vui-typography .vui-heading-1,
 			.d2l-typography .d2l-heading-1 {
 				@apply --d2l-heading-1;
 				@apply --d2l-heading-1-custom;
 			}
+
 			.vui-typography .vui-heading-2,
 			.d2l-typography .d2l-heading-2 {
 				@apply --d2l-heading-2;
 				@apply --d2l-heading-2-custom;
 			}
+
 			.vui-typography .vui-heading-3,
 			.d2l-typography .d2l-heading-3 {
 				@apply --d2l-heading-3;
 				@apply --d2l-heading-3-custom;
 			}
+
 			.vui-typography .vui-heading-4,
 			.d2l-typography .d2l-heading-4 {
 				@apply --d2l-heading-4;
 				@apply --d2l-heading-4-custom;
 			}
+
 			@media (max-width: 615px) {
 				.d2l-typography .d2l-heading-1,
 				.d2l-typography .vui-heading-1 {
@@ -167,6 +182,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-typography">
 					line-height: 0.9rem;
 				}
 			}
+
 		</style>
 	</template>
 </dom-module>`;

--- a/d2l-typography.js
+++ b/d2l-typography.js
@@ -2,48 +2,53 @@ import '@polymer/polymer/polymer-legacy.js';
 import 'd2l-colors/d2l-colors.js';
 import './d2l-typography-shared-styles.js';
 const importUrl = 'https://s.brightspace.com/lib/fonts/0.4.0/assets/';
+
+const $_fontFaces = document.createElement('style');
+$_fontFaces.id = 'd2l-typography-font-face';
+$_fontFaces.innerHTML = `
+	@font-face {
+		font-family: 'Lato';
+		font-style: normal;
+		font-weight: 400;
+		src: local('Lato Regular'), local('Lato-Regular'), url(${new URL('Lato-400.woff2', importUrl)}) format('woff2'), url(${new URL('Lato-400.woff', importUrl)}) format('woff'), url(${new URL('Lato-400.ttf', importUrl)}) format('truetype');
+	}
+	@font-face {
+		font-family: 'Lato';
+		font-style: normal;
+		font-weight: 700;
+		src: local('Lato Bold'), local('Lato-Bold'), url(${new URL('Lato-700.woff2', importUrl)}) format('woff2'), url(${new URL('Lato-700.woff', importUrl)}) format('woff'), url(${new URL('Lato-700.ttf', importUrl)}) format('truetype');
+	}
+	@font-face {
+		font-family: 'Open Dyslexic';
+		font-style: normal;
+		font-weight: 400;
+		src: local('Open Dyslexic Regular'), local('OpenDyslexic-Regular'), url(${new URL('OpenDyslexic.woff', importUrl)}) format('woff'), url(${new URL('OpenDyslexic.ttf', importUrl)}) format('truetype');
+	}
+	@font-face {
+		font-family: 'Open Dyslexic';
+		font-style: italic;
+		font-weight: 400;
+		src: local('Open Dyslexic Italic'), local('OpenDyslexic-Italic'), url(${new URL('OpenDyslexic-Italic.woff', importUrl)}) format('woff'), url(${new URL('OpenDyslexic-Italic.ttf', importUrl)}) format('truetype');
+	}
+	@font-face {
+		font-family: 'Open Dyslexic';
+		font-style: normal;
+		font-weight: 700;
+		src: local('Open Dyslexic Bold'), local('OpenDyslexic-Bold'), url(${new URL('OpenDyslexic-700.woff', importUrl)}) format('woff'), url(${new URL('OpenDyslexic-700.ttf', importUrl)}) format('truetype');
+	}
+	@font-face {
+		font-family: 'Open Dyslexic';
+		font-style: italic;
+		font-weight: 700;
+		src: local('Open Dyslexic Bold Italic'), local('OpenDyslexic-BoldItalic'), url(${new URL('OpenDyslexic-700-Italic.woff', importUrl)}) format('woff'), url(${new URL('OpenDyslexic-700-Italic.ttf', importUrl)}) format('truetype');
+	}`;
+document.head.appendChild($_fontFaces);
+
 const $_documentContainer = document.createElement('template');
 
 $_documentContainer.innerHTML = `<dom-module id="d2l-typography">
 	<template>
 		<style>
-			@font-face {
-				font-family: 'Lato';
-				font-style: normal;
-				font-weight: 400;
-				src: local('Lato Regular'), local('Lato-Regular'), url(${new URL('Lato-400.woff2', importUrl)}) format('woff2'), url(${new URL('Lato-400.woff', importUrl)}) format('woff'), url(${new URL('Lato-400.ttf', importUrl)}) format('truetype');
-			}
-			@font-face {
-				font-family: 'Lato';
-				font-style: normal;
-				font-weight: 700;
-				src: local('Lato Bold'), local('Lato-Bold'), url(${new URL('Lato-700.woff2', importUrl)}) format('woff2'), url(${new URL('Lato-700.woff', importUrl)}) format('woff'), url(${new URL('Lato-700.ttf', importUrl)}) format('truetype');
-			}
-			@font-face {
-				font-family: 'Open Dyslexic';
-				font-style: normal;
-				font-weight: 400;
-				src: local('Open Dyslexic Regular'), local('OpenDyslexic-Regular'), url(${new URL('OpenDyslexic.woff', importUrl)}) format('woff'), url(${new URL('OpenDyslexic.ttf', importUrl)}) format('truetype');
-			}
-			@font-face {
-				font-family: 'Open Dyslexic';
-				font-style: italic;
-				font-weight: 400;
-				src: local('Open Dyslexic Italic'), local('OpenDyslexic-Italic'), url(${new URL('OpenDyslexic-Italic.woff', importUrl)}) format('woff'), url(${new URL('OpenDyslexic-Italic.ttf', importUrl)}) format('truetype');
-			}
-			@font-face {
-				font-family: 'Open Dyslexic';
-				font-style: normal;
-				font-weight: 700;
-				src: local('Open Dyslexic Bold'), local('OpenDyslexic-Bold'), url(${new URL('OpenDyslexic-700.woff', importUrl)}) format('woff'), url(${new URL('OpenDyslexic-700.ttf', importUrl)}) format('truetype');
-			}
-			@font-face {
-				font-family: 'Open Dyslexic';
-				font-style: italic;
-				font-weight: 700;
-				src: local('Open Dyslexic Bold Italic'), local('OpenDyslexic-BoldItalic'), url(${new URL('OpenDyslexic-700-Italic.woff', importUrl)}) format('woff'), url(${new URL('OpenDyslexic-700-Italic.ttf', importUrl)}) format('truetype');
-			}
-
 			.d2l-typography,
 			.vui-typography {
 				color: var(--d2l-color-ferrite);
@@ -55,29 +60,23 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-typography">
 				line-height: 1.4rem;
 				@apply --d2l-font-custom;
 			}
-
 			.d2l-typography .d2l-body-standard {
 				@apply --d2l-body-standard-text;
 			}
-
 			.d2l-typography .d2l-body-compact {
 				@apply --d2l-body-compact-text;
 			}
-
 			.d2l-typography .d2l-body-small {
 				@apply --d2l-body-small-text;
 			}
-
 			.d2l-typography .d2l-label-text {
 				@apply --d2l-label-text;
 			}
-
 			.d2l-typography p,
 			.vui-typography p {
 				margin: 1rem 0;
 				@apply --d2l-font-paragraph-custom;
 			}
-
 			.d2l-typography.d2l-dyslexic,
 			.d2l-typography .d2l-dyslexic,
 			.vui-typography.vui-dyslexic,
@@ -86,59 +85,50 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-typography">
 				font-weight: 400;
 				@apply --d2l-font-dyslexic-custom;
 			}
-
 			.d2l-typography:lang(ar),
 			.d2l-typography :lang(ar),
 			.vui-typography:lang(ar),
 			.vui-typography :lang(ar) {
 				font-family: 'Arabic Transparent', 'Arabic Typesetting', 'Geeza Pro', sans-serif;
 			}
-
 			.d2l-typography:lang(zh),
 			.d2l-typography :lang(zh),
 			.vui-typography:lang(zh),
 			.vui-typography :lang(zh) {
 				font-family: 'Microsoft YaHei', 'Hiragino Sans GB', sans-serif;
 			}
-
 			.d2l-typography:lang(ko),
 			.d2l-typography :lang(ko),
 			.vui-typography:lang(ko),
 			.vui-typography :lang(ko) {
 				font-family: 'Apple SD Gothic Neo', Dotum, sans-serif;
 			}
-
 			.d2l-typography:lang(ja),
 			.d2l-typography :lang(ja),
 			.vui-typography:lang(ja),
 			.vui-typography :lang(ja) {
 				font-family: 'Hiragino Kaku Gothic Pro', 'Meiyro', sans-serif;
 			}
-
 			.vui-typography .vui-heading-1,
 			.d2l-typography .d2l-heading-1 {
 				@apply --d2l-heading-1;
 				@apply --d2l-heading-1-custom;
 			}
-
 			.vui-typography .vui-heading-2,
 			.d2l-typography .d2l-heading-2 {
 				@apply --d2l-heading-2;
 				@apply --d2l-heading-2-custom;
 			}
-
 			.vui-typography .vui-heading-3,
 			.d2l-typography .d2l-heading-3 {
 				@apply --d2l-heading-3;
 				@apply --d2l-heading-3-custom;
 			}
-
 			.vui-typography .vui-heading-4,
 			.d2l-typography .d2l-heading-4 {
 				@apply --d2l-heading-4;
 				@apply --d2l-heading-4-custom;
 			}
-
 			@media (max-width: 615px) {
 				.d2l-typography .d2l-heading-1,
 				.d2l-typography .vui-heading-1 {
@@ -177,7 +167,6 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-typography">
 					line-height: 0.9rem;
 				}
 			}
-
 		</style>
 	</template>
 </dom-module>`;


### PR DESCRIPTION
When including `d2l-typography.js` in our FRA (d2l-class-stream), we are having issues with getting the font-faces to load.
While they are appended to the document head as intended, that still fails to apply the font to the component. We believe this is related to known shadow DOM issues in firefox and chrome, especially since it works in Edge and IE (See this thread https://d2l.slack.com/archives/CDJE0AYMB/p1548978860141300).

The idea if this fix is to extract the font-faces and appends them as a `<style>` element, rather than a template.