### PR TITLE
Add automatic CI versioning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,20 @@ script:
     echo "Pull request with secure environment variables, running Sauce tests...";
     npm run test:galen:sauce || travis_terminate 1;
   fi
+- |
+  if [ "$TRAVIS_BRANCH" == "master" ] && [ $TRAVIS_PULL_REQUEST == false ]; then
+    echo "Not a Pull Request and on branch master so bumping version";
+    frauci-update-version;
+    export TRAVIS_TAG=$(frauci-get-version)
+  fi
+deploy:
+  provider: releases
+  api_key: "$GITHUB_RELEASE_TOKEN"
+  on:
+    tags: true
 env:
   global:
+  - REPO_NAME=typography
   - SAUCE_USERNAME: Desire2Learn
   - secure: DJvA0W0U/k26O2GETOEf2Lz3RcBW936cdm5Nzw75h3WL2Cu6MHee/9hM69JMostWqyPnbbzUNv0swwRCY8ZPfNkboHMZQRNxrUpp9yN9zz9mrXTn/qUi5bSP41DjJO8yqvYlSGO83tKN/dnvhgwYlWmGot3oJ12XB0ItO/kb868=
+  - secure: Ms8j6W8edeEEiue73sMjyeircrPDUcIlq9xxHN35NStolxGB9GVKzPyHlTAyShDO2Jqm48W0cyFa7ketCc3w0v42uF97u28xRtIhjmY2SYsVDj+PeVuckoBJM+2eqvkM94e/2hOjkQLvOc40BIZL9qXafIUp21tXmmYstvUvIk0=

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ deploy:
     tags: true
 env:
   global:
+  - OWNER_NAME=BrightspaceUI
   - REPO_NAME=typography
   - SAUCE_USERNAME: Desire2Learn
   - secure: DJvA0W0U/k26O2GETOEf2Lz3RcBW936cdm5Nzw75h3WL2Cu6MHee/9hM69JMostWqyPnbbzUNv0swwRCY8ZPfNkboHMZQRNxrUpp9yN9zz9mrXTn/qUi5bSP41DjJO8yqvYlSGO83tKN/dnvhgwYlWmGot3oJ12XB0ItO/kb868=

--- a/README.md
+++ b/README.md
@@ -171,3 +171,12 @@ See the [Best Practices & Style Guide](https://github.com/Brightspace/valence-ui
 [bower-image]: https://badge.fury.io/bo/d2l-typography.svg
 [ci-url]: https://travis-ci.org/BrightspaceUI/typography
 [ci-image]: https://img.shields.io/travis-ci/BrightspaceUI/typography.svg
+
+## Versioning
+
+Commits and PR merges to master will automatically do a minor version bump which will:
+* Update the version in `package.json`
+* Add a tag matching the new version
+* Create a github release matching the new version
+
+By using either **[increment major]** or **[increment patch]** notation inside your merge message, you can overwrite the default version upgrade of minor to the position of your choice.

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "sauce-connect-launcher": "^1.2.4",
     "sauceconnect-runner": "git+https://github.com/Brightspace/sauceconnect-runner.git#v0.3.0"
   },
-  "version": "",
+  "version": "7.0.4",
   "resolutions": {
     "inherits": "2.0.3",
     "samsam": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "sauce-connect-launcher": "^1.2.4",
     "sauceconnect-runner": "git+https://github.com/Brightspace/sauceconnect-runner.git#v0.3.0"
   },
-  "version": "7.0.4",
+  "version": "7.0.5",
   "resolutions": {
     "inherits": "2.0.3",
     "samsam": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "sauce-connect-launcher": "^1.2.4",
     "sauceconnect-runner": "git+https://github.com/Brightspace/sauceconnect-runner.git#v0.3.0"
   },
-  "version": "7.0.3",
+  "version": "7.0.4",
   "resolutions": {
     "inherits": "2.0.3",
     "samsam": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "eslint": "^4.15.0",
     "eslint-config-brightspace": "^0.4.0",
     "eslint-plugin-html": "^4.0.1",
+    "frau-ci": "^1.33.2",
     "galenframework": "^2.3.2",
     "node-sass": "^4.5.0",
     "polymer-cli": "^1.9.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "sauce-connect-launcher": "^1.2.4",
     "sauceconnect-runner": "git+https://github.com/Brightspace/sauceconnect-runner.git#v0.3.0"
   },
-  "version": "7.0.4",
+  "version": "7.0.3",
   "resolutions": {
     "inherits": "2.0.3",
     "samsam": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "sauce-connect-launcher": "^1.2.4",
     "sauceconnect-runner": "git+https://github.com/Brightspace/sauceconnect-runner.git#v0.3.0"
   },
-  "version": "7.0.6",
+  "version": "7.0.7",
   "resolutions": {
     "inherits": "2.0.3",
     "samsam": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "sauce-connect-launcher": "^1.2.4",
     "sauceconnect-runner": "git+https://github.com/Brightspace/sauceconnect-runner.git#v0.3.0"
   },
-  "version": "7.0.5",
+  "version": "7.0.6",
   "resolutions": {
     "inherits": "2.0.3",
     "samsam": "1.1.3",


### PR DESCRIPTION
Updates travis.yml to use frauci-update-version to bump package.json version and tag commit on each commit/pr merge to master. Use travis releases provider to create a new github release matching tag.